### PR TITLE
Enable Swagger UI.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,17 @@
             <version>1.18.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>2.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>2.7.0</version>
+        </dependency>
+
     </dependencies>
 
     <properties>

--- a/src/main/java/org/tony/TestApp.java
+++ b/src/main/java/org/tony/TestApp.java
@@ -2,10 +2,28 @@ package org.tony;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Optional;
 
 @SpringBootApplication
+@EnableSwagger2
+//https://www.tutorialspoint.com/spring_boot/spring_boot_enabling_swagger2.htm
 public class TestApp {
     public static void main(String[] args) {
         SpringApplication.run(TestApp.class);
+    }
+    @Bean
+    public Docket testAppApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("org.tony"))
+                .build()
+                .genericModelSubstitutes(Optional.class); //To make Java 8 Optional @RequestParam  show in the sawgger ui, we have to add ".genericModelSubstitutes( Optional.class )" to the Docket-Bean creation.
+                //https://github.com/springfox/springfox/issues/1848
     }
 }

--- a/src/main/java/org/tony/controller/GreetingController.java
+++ b/src/main/java/org/tony/controller/GreetingController.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import org.tony.config.TestAppConfiguration;
 
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
 @RestController
 public class GreetingController {
 
@@ -18,9 +20,11 @@ public class GreetingController {
     private  TestAppConfiguration testAppConfiguration;
     //Not work when adding final //private final TestAppConfiguration testAppConfiguration;
 
-    @RequestMapping("/greeting")
+    @RequestMapping(value = "/greeting", method = GET )  //If we ignore method, all of the methods, i.e., GET/POST/DELETE show in the swagger ui.
     public Greeting greeting(@RequestParam(value="name") Optional<String> name) {
         return new Greeting(counter.incrementAndGet(),
                 String.format(testAppConfiguration.getTemplate(), name.orElse(testAppConfiguration.getDefaultName())));
+        //Adding lombok to pom.xml makes it works for runtime. Only if installing lombok plugin in Intellij,  can we see the  getter/setter directly.
+        //https://www.baeldung.com/lombok-ide
     }
 }


### PR DESCRIPTION
Mainly Enable Swagger UI.
And to make Java 8 Optional @RequestParam  shows in the sawgger ui, we have to add ".genericModelSubstitutes( Optional.class )" to the Docket-Bean creation as it says in https://github.com/springfox/springfox/issues/1848
 
BTW,  about lombok,
   Adding lombok to pom.xml makes it works for runtime. Only if installing lombok plugin in Intellij,  can we see the  getter/setter directly. 
      https://www.baeldung.com/lombok-ide